### PR TITLE
Replace emails with links from maintainers

### DIFF
--- a/pkg/resource/file_repository_test.go
+++ b/pkg/resource/file_repository_test.go
@@ -26,12 +26,12 @@ func buildResourcesFromFixtures() []*Resource {
 			Icon:        "https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Apache_HTTP_server_logo_%282016%29.svg/300px-Apache_HTTP_server_logo_%282016%29.svg.png",
 			Maintainers: []*Maintainer{
 				{
-					Name:  "nestorsalceda",
-					Email: "nestor.salceda@sysdig.com",
+					Name: "nestorsalceda",
+					Link: "github.com/nestorsalceda",
 				},
 				{
-					Name:  "fedebarcelona",
-					Email: "fede.barcelona@sysdig.com",
+					Name: "fedebarcelona",
+					Link: "github.com/tembleking",
 				},
 			},
 			Rules: []*FalcoRuleData{
@@ -51,12 +51,12 @@ func buildResourcesFromFixtures() []*Resource {
 			Icon:        "https://upload.wikimedia.org/wikipedia/en/thumb/4/45/MongoDB-Logo.svg/2560px-MongoDB-Logo.svg.png",
 			Maintainers: []*Maintainer{
 				{
-					Name:  "nestorsalceda",
-					Email: "nestor.salceda@sysdig.com",
+					Name: "nestorsalceda",
+					Link: "github.com/nestorsalceda",
 				},
 				{
-					Name:  "fedebarcelona",
-					Email: "fede.barcelona@sysdig.com",
+					Name: "fedebarcelona",
+					Link: "github.com/tembleking",
 				},
 			},
 			Rules: []*FalcoRuleData{

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -76,8 +76,8 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 }
 
 type Maintainer struct {
-	Name  string `json:"name" yaml:"name"`
-	Email string `json:"email" yaml:"email"`
+	Name string `json:"name" yaml:"name"`
+	Link string `json:"link" yaml:"link"`
 }
 
 type FalcoRuleData struct {

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -54,8 +54,8 @@ func newResource() Resource {
 		Icon:        "https://sysdig.com/icon.png",
 		Maintainers: []*Maintainer{
 			{
-				Name:  "bencer",
-				Email: "bencer@sysdig.com",
+				Name: "bencer",
+				Link: "github.com/bencer",
 			},
 		},
 	}

--- a/test/fixtures/resources/apache.yaml
+++ b/test/fixtures/resources/apache.yaml
@@ -10,9 +10,9 @@ keywords:
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Apache_HTTP_server_logo_%282016%29.svg/300px-Apache_HTTP_server_logo_%282016%29.svg.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: apache_consider_syscalls

--- a/test/fixtures/resources/mongo.yaml
+++ b/test/fixtures/resources/mongo.yaml
@@ -10,9 +10,9 @@ keywords:
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/45/MongoDB-Logo.svg/2560px-MongoDB-Logo.svg.png
 maintainers:
   - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+    link: github.com/nestorsalceda
   - name: fedebarcelona
-    email: fede.barcelona@sysdig.com
+    link: github.com/tembleking
 rules:
   - raw: |
       - macro: mongo_consider_syscalls


### PR DESCRIPTION
Maybe a maintainer doesn't want to publish it's e-mail, this PR replaces the e-mail with a generic link from the maintainer structure.
